### PR TITLE
Table component nested array children fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2021-06-14
+
+- Table component nested array children fix
+
 ## [1.11.0] - 2021-06-10
 
 - Icons

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmerconnect/farmerconnect-ui",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "dist/farmerconnect-ui.cjs.js",
   "module": "dist/farmerconnect-ui.esm.js",
   "scripts": {

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -1,7 +1,13 @@
 import React, { useMemo, useCallback, ReactNode, isValidElement, ReactElement } from 'react';
 import IconArrow from '../Icons/Arrow';
 import { SORT_ORDER } from './constants';
-import { ITableChildren, ITableColumn, ITableColumnOptions, ITableProps } from './interfaces';
+import {
+  ITableChildren,
+  ITableColumn,
+  ITableColumnOptions,
+  ITableProps,
+  TableCloneChildrenFunction,
+} from './interfaces';
 import * as S from './styles';
 
 const Table: React.FC<ITableProps> = ({ sort, columns, children, onSortChange }) => {
@@ -69,9 +75,13 @@ const Table: React.FC<ITableProps> = ({ sort, columns, children, onSortChange })
   );
 
   const applyToChildren = useCallback(
-    (fn: (children: ITableChildren) => ReactElement | null, children: ReactNode, key?: string) => {
+    (fn: TableCloneChildrenFunction, children: ReactNode, key?: string): ReactNode => {
       if (Array.isArray(children)) {
-        return children.map((child: ReactNode, index: number) => fn({ element: child, key, index }));
+        return children.map((child: ReactNode, index: number) => {
+          if (Array.isArray(child)) return applyToChildren(fn, child, key);
+
+          return fn({ element: child, key, index });
+        });
       }
 
       return fn({ element: children, key });

--- a/src/components/Table/interfaces.ts
+++ b/src/components/Table/interfaces.ts
@@ -1,4 +1,6 @@
-import { HTMLAttributes, ReactNode } from 'react';
+import { HTMLAttributes, ReactElement, ReactNode } from 'react';
+
+export type TableCloneChildrenFunction = (children: ITableChildren) => ReactElement | null;
 
 interface ITableColumnOptionsSortable {
   key: string;


### PR DESCRIPTION
Fixing the children behavior when its structure was like this:

```
<Table ...>
  {items.map((item) => <Table.Row>...</Table.Row>)}

  {!items.length && <Table.Row>...</Table.Row>} // Empty message
</Table>
```