### PR TITLE
fix(pagination): displayed items text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.36.1] - 2021-10-13
+
+- Displayed items count text now fits.
+- Add hasItemCount prop to toggle item count display.
+
 ## [1.36.0] - 2021-10-12
 
 - Add Pagination component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmerconnect/farmerconnect-ui",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "main": "dist/farmerconnect-ui.cjs.js",
   "module": "dist/farmerconnect-ui.esm.js",
   "scripts": {

--- a/src/components/Pagination/index.stories.tsx
+++ b/src/components/Pagination/index.stories.tsx
@@ -64,7 +64,17 @@ export default {
       },
     },
     hasSelect: {
-      description: 'Turns the page size select.',
+      description: 'Show/hides the page size select.',
+      defaultValue: true,
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: true },
+      },
+    },
+    hasItemCount: {
+      description: 'Show/hides the item count text.',
       defaultValue: true,
       control: {
         type: 'boolean',
@@ -74,7 +84,7 @@ export default {
       },
     },
     hasArrows: {
-      description: 'Turns the next and previous page arrows on and off',
+      description: 'Shows/hides the next and previous page arrows',
       defaultValue: true,
       control: {
         type: 'boolean',

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -18,6 +18,7 @@ import Typography from '../Typography';
 const MIN_NUMBER_OF_PAGES = 5;
 
 const defaultProps = {
+  hasItemCount: true,
   hasSelect: true,
   hasArrows: true,
   pageSizeLabelTemplate: (pageSize: number) => `${pageSize} / page`,
@@ -30,6 +31,7 @@ const Pagination: React.FC<IPaginationProps> = (incomingProps: IPaginationProps)
   const {
     hasSelect = defaultProps.hasSelect,
     hasArrows = defaultProps.hasArrows,
+    hasItemCount = defaultProps.hasItemCount,
     pageSizeLabelTemplate = defaultProps.pageSizeLabelTemplate,
     pageSizeArray = defaultProps.pageSizeArray,
     displayedItemsTemplate = defaultProps.displayedItemsTemplate,
@@ -113,8 +115,8 @@ const Pagination: React.FC<IPaginationProps> = (incomingProps: IPaginationProps)
 
   return (
     <S.PaginationContainer {...props}>
-      {hasSelect && (
-        <S.SelectContainer>
+      <S.SelectContainer>
+        {hasSelect && (
           <S.PageCount>
             <SmallSelect
               onChange={onSelectChange}
@@ -122,11 +124,13 @@ const Pagination: React.FC<IPaginationProps> = (incomingProps: IPaginationProps)
               options={selectOptions}
             ></SmallSelect>
           </S.PageCount>
+        )}
+        {hasItemCount && (
           <Typography variant="small" tagName="span">
             {displayedItemsTemplate(firstItemOnPage, lastItemOnPage, pagination.totalItemCount)}
           </Typography>
-        </S.SelectContainer>
-      )}
+        )}
+      </S.SelectContainer>
       <S.ButtonsContainer>
         {hasArrows && pagination.currentPageIndex !== 0 && (
           <PaginationArrowButton

--- a/src/components/Pagination/interfaces.ts
+++ b/src/components/Pagination/interfaces.ts
@@ -53,6 +53,7 @@ export type ISelectOption = { selected: boolean; label: string; value: string };
 export type ISelectOptionArray = ReadonlyArray<ISelectOption>;
 
 export interface IPaginationProps extends HTMLAttributes<HTMLDivElement> {
+  hasItemCount?: boolean;
   hasSelect?: boolean;
   pageSizeArray?: number[];
   pageSizeLabelTemplate?: PageSizeLabelTemplate;

--- a/src/components/Pagination/styles.ts
+++ b/src/components/Pagination/styles.ts
@@ -2,8 +2,7 @@ import { IPaginationProps } from './interfaces';
 import styled from 'styled-components';
 
 export const PageCount = styled.div<any>`
-  min-width: 100%;
-  width: max-content;
+  width: 10rem;
 `;
 
 export const ButtonsContainer = styled.div<any>`


### PR DESCRIPTION
Displayed items text is given enough horizontal space.
Add hasItemCount prop to turn displayed items count on and off.

AB#4716